### PR TITLE
remove deprecated call `bottle :unneeded`

### DIFF
--- a/isaka.rb
+++ b/isaka.rb
@@ -3,7 +3,6 @@ class Isaka < Formula
   desc "tail log for Apache Kafka"
   homepage "https://github.com/pyama86/isaka"
   version "0.0.4"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/pyama86/isaka/releases/download/v0.0.4/isaka_0.0.4_darwin_amd64.tar.gz"


### PR DESCRIPTION
It is deprecated.

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the pyama86/isaka tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/pyama86/homebrew-isaka/isaka.rb:6
```